### PR TITLE
Add tox.ini for automatic environment creation.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[testenv]
+commands =
+	pytest -v --cov src/mypy_zope
+	mypy src/mypy_zope --strict
+usedevelop = True
+extras = test


### PR DESCRIPTION
This commit adds a tox.ini, allowing the tests to be run in an isolated virtualenv with a simple `tox` invocation or in multiple with for example `tox -e py37,py38`.