### PR TITLE
Add flake8 configuration to honor black preferences.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 88
+ignore =
+	# Black creates whitespace before colon
+	E203


### PR DESCRIPTION
My editor (SublimeText) has flake8 integrated. As a result, it warns about line lengths (and potentially other violations). Adding this file suppresses those warnings as pertinent to the black code style.