### PR TITLE
Add support for InterfaceClass as a metaclass.

### DIFF
--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -258,14 +258,12 @@ class ZopeInterfacePlugin(Plugin):
         self, fullname: str
     ) -> Optional[Callable[[ClassDefContext], None]]:
         # print(f"get_metaclass_hook: {fullname}")
-        def analyze_metaclass(
-            ctx: ClassDefContext,
-        ) -> Callable[[ClassDefContext], None]:
-            def is_zope_interface_class(info):
-                expected = "zope.interface.interface.InterfaceClass"
-                return info and any(node.fullname == expected for node in info.mro)
-
-            if is_zope_interface_class(ctx.cls.metaclass.node):
+        def analyze_metaclass(ctx: ClassDefContext) -> None:
+            metaclass = ctx.cls.metaclass
+            info = metaclass.node
+            expected = "zope.interface.interface.InterfaceClass"
+            if info and any(node.fullname == expected for node in info.mro):
+                self.log(f"Found zope interface: {ctx.cls.fullname}")
                 md = self._get_metadata(ctx.cls.info)
                 md["is_interface"] = True
 

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -258,14 +258,17 @@ class ZopeInterfacePlugin(Plugin):
         self, fullname: str
     ) -> Optional[Callable[[ClassDefContext], None]]:
         # print(f"get_metaclass_hook: {fullname}")
-        def analyze_metaclass(ctx: ClassDefContext) -> Callable[[ClassDefContext], None]:
+        def analyze_metaclass(
+            ctx: ClassDefContext,
+        ) -> Callable[[ClassDefContext], None]:
             def is_zope_interface_class(info):
-                expected = 'zope.interface.interface.InterfaceClass'
+                expected = "zope.interface.interface.InterfaceClass"
                 return info and any(node.fullname == expected for node in info.mro)
 
             if is_zope_interface_class(ctx.cls.metaclass.node):
                 md = self._get_metadata(ctx.cls.info)
                 md["is_interface"] = True
+
         return analyze_metaclass
 
     def get_base_class_hook(

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -258,7 +258,11 @@ class ZopeInterfacePlugin(Plugin):
         self, fullname: str
     ) -> Optional[Callable[[ClassDefContext], None]]:
         # print(f"get_metaclass_hook: {fullname}")
-        return None
+        def analyze_metaclass(ctx: ClassDefContext) -> Callable[[ClassDefContext], None]:
+            if ctx.cls.metaclass.name == 'InterfaceClass':
+                md = self._get_metadata(ctx.cls.info)
+                md["is_interface"] = True
+        return analyze_metaclass
 
     def get_base_class_hook(
         self, fullname: str

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -259,7 +259,11 @@ class ZopeInterfacePlugin(Plugin):
     ) -> Optional[Callable[[ClassDefContext], None]]:
         # print(f"get_metaclass_hook: {fullname}")
         def analyze_metaclass(ctx: ClassDefContext) -> Callable[[ClassDefContext], None]:
-            if ctx.cls.metaclass.name == 'InterfaceClass':
+            def is_zope_interface_class(info):
+                expected = 'zope.interface.interface.InterfaceClass'
+                return info and any(node.fullname == expected for node in info.mro)
+
+            if is_zope_interface_class(ctx.cls.metaclass.node):
                 md = self._get_metadata(ctx.cls.info)
                 md["is_interface"] = True
         return analyze_metaclass

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -274,11 +274,6 @@ class ZopeInterfacePlugin(Plugin):
         self, fullname: str
     ) -> Optional[Callable[[ClassDefContext], None]]:
         # print(f"get_base_class_hook: {fullname}")
-        def analyze_direct(classdef_ctx: ClassDefContext) -> None:
-            self.log(f"Found zope interface: {classdef_ctx.cls.fullname}")
-            md = self._get_metadata(classdef_ctx.cls.info)
-            md["is_interface"] = True
-
         def analyze_subinterface(classdef_ctx: ClassDefContext) -> None:
             # If one of the bases is an interface, this is also an interface
             if isinstance(classdef_ctx.reason, IndexExpr):
@@ -309,9 +304,6 @@ class ZopeInterfacePlugin(Plugin):
                 self.log(f"Found zope subinterface: {cls_info.fullname}")
                 cls_md = self._get_metadata(cls_info)
                 cls_md["is_interface"] = True
-
-        if fullname == "zope.interface.interface.Interface":
-            return analyze_direct
 
         return analyze_subinterface
 

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -48,6 +48,7 @@ from mypy.nodes import (
     ARG_POS,
     ARG_OPT,
     FUNC_NO_INFO,
+    NameExpr,
 )
 
 from collections import defaultdict
@@ -259,8 +260,8 @@ class ZopeInterfacePlugin(Plugin):
     ) -> Optional[Callable[[ClassDefContext], None]]:
         # print(f"get_metaclass_hook: {fullname}")
         def analyze_metaclass(ctx: ClassDefContext) -> None:
-            metaclass = ctx.cls.metaclass
-            info = metaclass.node
+            metaclass = cast(NameExpr, ctx.cls.metaclass)
+            info = cast(TypeInfo, metaclass.node)
             expected = "zope.interface.interface.InterfaceClass"
             if info and any(node.fullname == expected for node in info.mro):
                 self.log(f"Found zope interface: {ctx.cls.fullname}")

--- a/tests/samples/interface_metaclass.py
+++ b/tests/samples/interface_metaclass.py
@@ -1,0 +1,10 @@
+from zope.interface import interface
+
+
+class RemoteInterface(metaclass=interface.InterfaceClass):
+    pass
+
+
+class Api(RemoteInterface):
+    def open():
+        "open something"


### PR DESCRIPTION
Addresses #21 by adding support for any InterfaceClass as a metaclass.

Doesn't yet address the case where the class is created through direct instantiation of the InterfaceClass subtype.