### PR TITLE
Runtime-safe way to check types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 0.2.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Avoid failure when handling metaclasses of unknown type (#28).
 
 
-0.2.9 (2021-01-23)
+## [0.2.9] - 2021-01-23
 
 - Upgrade to Mypy-0.800
 - Add support for Python 3.9.

--- a/tests/samples/unknown_metaclass.py
+++ b/tests/samples/unknown_metaclass.py
@@ -1,0 +1,15 @@
+"""When metaclass is not defined, ignore it"""
+
+from i.dont.exist import MetaKlass
+
+
+class Leg(metaclass=MetaKlass):
+    pass
+
+
+"""
+<output>
+unknown_metaclass.py:3: error: Cannot find implementation or library stub for module named 'i.dont.exist'
+unknown_metaclass.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+</output>
+"""


### PR DESCRIPTION
Avoid failure when handling metaclasses of unknown type.

Fixes #28