### PR TITLE
Prefer DefaultPlugin to handle functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 0.2.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Better type inference for contextmanagers and open() function: do not override 
+  the default behavior for tese cases
 
 
 0.2.11 (2021-02-21)

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -15,6 +15,7 @@ from mypy.types import (
     FunctionLike,
 )
 from mypy.checker import TypeChecker, is_false_literal
+from mypy.options import Options
 from mypy.nodes import TypeInfo
 from mypy.plugin import (
     CheckerPluginInterface,
@@ -28,6 +29,7 @@ from mypy.plugin import (
     ClassDefContext,
 )
 from mypy.subtypes import find_member
+from mypy.plugins.default import DefaultPlugin
 
 from mypy.nodes import (
     Context,
@@ -91,6 +93,10 @@ SIMPLE_FIELD_TO_TYPE = {
 
 
 class ZopeInterfacePlugin(Plugin):
+    def __init__(self, options: Options):
+        super().__init__(options)
+        self.fallback = DefaultPlugin(options)
+
     def log(self, msg: str) -> None:
         if self.options.verbosity >= 1:
             print("ZOPE:", msg, file=sys.stderr)
@@ -121,6 +127,10 @@ class ZopeInterfacePlugin(Plugin):
 
             return deftype
 
+        # Give preference to deault plugin
+        hook = self.fallback.get_function_hook(fullname)
+        if hook is not None:
+            return hook
         return analyze
 
     def get_method_signature_hook(

--- a/tests/samples/contextmanager.py
+++ b/tests/samples/contextmanager.py
@@ -1,0 +1,25 @@
+from collections import Iterator
+from contextlib import contextmanager
+from typing import TypeVar, Generic
+
+_T = TypeVar("_T")
+
+
+class A(Generic[_T]):
+    pass
+
+@contextmanager
+def m(x: _T) -> Iterator[A[_T]]:
+    ...
+
+
+with m(7) as x:
+    reveal_type(x)
+    print(x)
+
+
+"""
+<output>
+contextmanager.py:17: note: Revealed type is '__main__.A*[builtins.int*]'
+</output>
+"""

--- a/tests/samples/open.py
+++ b/tests/samples/open.py
@@ -1,0 +1,9 @@
+reveal_type(open('str'))
+reveal_type(open('str', 'b'))
+
+"""
+<output>
+open.py:1: note: Revealed type is 'typing.TextIO'
+open.py:2: note: Revealed type is 'typing.BinaryIO'
+</output>
+"""


### PR DESCRIPTION
This will allow to correctly infer types for contextmanagers and open function when mypy-zope plugin is enabled.

Fixes #35
Fixes #16