### PR TITLE
Required work for mypy 920

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages =
     zope-stubs
 package_dir = =src
 install_requires =
-    mypy==0.910
+    mypy==0.920
     zope.interface
     zope.schema
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Software Development

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Operating System :: OS Independent
     Topic :: Software Development
 
-
 [options]
 packages =
     mypy_zope

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Operating System :: OS Independent
     Topic :: Software Development
 
+
 [options]
 packages =
     mypy_zope

--- a/tests/samples/contextmanager.py
+++ b/tests/samples/contextmanager.py
@@ -1,6 +1,5 @@
-from collections import Iterator
 from contextlib import contextmanager
-from typing import TypeVar, Generic
+from typing import Iterator, TypeVar, Generic
 
 _T = TypeVar("_T")
 

--- a/tests/samples/contextmanager.py
+++ b/tests/samples/contextmanager.py
@@ -19,6 +19,6 @@ with m(7) as x:
 
 """
 <output>
-contextmanager.py:17: note: Revealed type is "__main__.A*[builtins.int*]"
+contextmanager.py:16: note: Revealed type is "__main__.A*[builtins.int*]"
 </output>
 """


### PR DESCRIPTION
Hi,

I just ran the latest mypy 0.920 master, looks like no updates were necesary. I also added python 3.10 to the trove classifiers.

It looks like we'll see a new mypy this week.

Cheers

