### PR TITLE
Upgrade to mypy 0.981

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 0.3.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Upgrade to Mypy-0.981.
 
 
 0.3.9 (2022-07-19)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages =
     zope-stubs
 package_dir = =src
 install_requires =
-    mypy==0.971
+    mypy==0.981
     zope.interface
     zope.schema
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Environment :: Console
     Intended Audience :: Developers
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
`mypy==981` seems to have dropped support for Python 3.6, so I've removed relevant build setup and classifiers.