### PR TITLE
Fix the MRO order and correctly add metaclass types

### DIFF
--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -698,7 +698,9 @@ class ZopeInterfacePlugin(Plugin):
         if not any(promote in ti._promote for ti in impl.mro):
             faketi = TypeInfo(SymbolTable(), iface.defn, iface.module_name)
             faketi._promote = [promote]
-            impl.mro.append(faketi)
+            faketi.metaclass_type = iface.metaclass_type
+            # Insert the TypeInfo before the builtins.object that's at the end.
+            impl.mro.insert(len(impl.mro) - 1, faketi)
 
 
 def plugin(version: str) -> PyType[Plugin]:

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -700,6 +700,7 @@ class ZopeInterfacePlugin(Plugin):
             faketi._promote = [promote]
             faketi.metaclass_type = iface.metaclass_type
             # Insert the TypeInfo before the builtins.object that's at the end.
+            assert impl.mro[-1].fullname == 'builtins.object'
             impl.mro.insert(len(impl.mro) - 1, faketi)
 
 

--- a/tests/test_mro_calculation.py
+++ b/tests/test_mro_calculation.py
@@ -59,10 +59,10 @@ def test_mro_computation_in_forward_reference_to_implementer(mypy_cache_dir: str
     mro: List[TypeInfo] = node.node.mro
     # Expected: [
     #   <TypeInfo forward_reference_to_implementer.Protocol@21>,
-    #   <TypeInfo builtins.object>,
     #   <TypeInfo forward_reference_to_implementer.IProtocol>,
+    #   <TypeInfo builtins.object>,
     # ]
     assert len(mro) == 3
     assert mro[0].fullname.startswith(f"{sample_name}.Protocol")
-    assert mro[1].fullname == "builtins.object"
-    assert mro[2].fullname == f"{sample_name}.IProtocol"
+    assert mro[1].fullname == f"{sample_name}.IProtocol"
+    assert mro[2].fullname == "builtins.object"


### PR DESCRIPTION
This fixes the caching error at #86 by ensuring that the faketi has the same metaclass_type as the TypeInfo that is being faked. I also adjusted the MRO so that builtins.object is correctly ignored by the mypy code.  (It expected the MRO to end with builtins.object)

Note: This does not fix the fact that mypy 1.0.0 will show a:
> error: Metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases  [misc]

This only ensures that error shows up every time so that it can be `# type: ignore`d if you want.

Closes #86 