### PR TITLE
Attempt to make the test suite pass under mypy 1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages =
     zope-stubs
 package_dir = =src
 install_requires =
-    mypy==0.981
+    mypy==1.0.0
     zope.interface
     zope.schema
 include_package_data = True

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -482,9 +482,6 @@ class ZopeInterfacePlugin(Plugin):
                 replacement = self._adjust_interface_function(api, cls.info, item)
             elif isinstance(item, OverloadedFuncDef):
                 replacement = self._adjust_interface_overload(api, cls.info, item)
-            elif isinstance(item, Decorator):
-                replacement = item
-                replacement.func = self._adjust_interface_function(api, cls.info, item.func)
             else:
                 continue
 

--- a/src/mypy_zope/plugin.py
+++ b/src/mypy_zope/plugin.py
@@ -482,6 +482,9 @@ class ZopeInterfacePlugin(Plugin):
                 replacement = self._adjust_interface_function(api, cls.info, item)
             elif isinstance(item, OverloadedFuncDef):
                 replacement = self._adjust_interface_overload(api, cls.info, item)
+            elif isinstance(item, Decorator):
+                replacement = item
+                replacement.func = self._adjust_interface_function(api, cls.info, item.func)
             else:
                 continue
 

--- a/tests/samples/contextmanager.py
+++ b/tests/samples/contextmanager.py
@@ -9,7 +9,7 @@ class A(Generic[_T]):
 
 @contextmanager
 def m(x: _T) -> Iterator[A[_T]]:
-    ...
+    return iter([A()])
 
 
 with m(7) as x:

--- a/tests/samples/interface_meta.py
+++ b/tests/samples/interface_meta.py
@@ -7,7 +7,7 @@ T = TypeVar('T', bound='zope.interface.Interface')
 class IBookmark(zope.interface.Interface):
     @staticmethod
     def create(url: str) -> 'IBookmark':
-        pass
+        return IBookmark(url)
 
 def createOb(iface: Type[T]) -> T:
     if zope.interface.interfaces.IInterface.providedBy(iface):

--- a/tests/samples/interface_meta.py
+++ b/tests/samples/interface_meta.py
@@ -5,9 +5,7 @@ T = TypeVar('T', bound='zope.interface.Interface')
 
 
 class IBookmark(zope.interface.Interface):
-    @staticmethod
-    def create(url: str) -> 'IBookmark':
-        return IBookmark(url)
+    pass
 
 def createOb(iface: Type[T]) -> T:
     if zope.interface.interfaces.IInterface.providedBy(iface):
@@ -20,6 +18,6 @@ def main(self) -> None:
 
 """
 <output>
-interface_meta.py:19: note: Revealed type is "__main__.IBookmark"
+interface_meta.py:17: note: Revealed type is "__main__.IBookmark"
 </output>
 """

--- a/tests/samples/interface_unknown_inherit.py
+++ b/tests/samples/interface_unknown_inherit.py
@@ -20,7 +20,7 @@ class Bookmark(object):
 <output>
 interface_unknown_inherit.py:8: error: Cannot find implementation or library stub for module named "unknown.interfaces"
 interface_unknown_inherit.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-interface_unknown_inherit.py:11: error: Method must have at least one argument
+interface_unknown_inherit.py:11: error: Method must have at least one argument. Did you forget the "self" argument?
 interface_unknown_inherit.py:14: error: zope.interface.implementer accepts interface, not __main__.IKnownInterface.
 interface_unknown_inherit.py:14: error: Make sure you have stubs for all packages that provide interfaces for __main__.IKnownInterface class hierarchy.
 </output>

--- a/tests/samples/overload_readme.py
+++ b/tests/samples/overload_readme.py
@@ -14,7 +14,7 @@ class IAnimal(zope.interface.Interface):
     def say(count: int) -> List[str]:
         ...
 
-    def say(count: int = None) -> Union[str, List[str]]:
+    def say(count: Optional[int] = None) -> Union[str, List[str]]:
         pass
 
 
@@ -28,7 +28,7 @@ class Cow(object):
     def say(self, count: int) -> List[str]:
         ...
 
-    def say(self, count: int = None) -> Union[str, List[str]]:
+    def say(self, count: Optional[int] = None) -> Union[str, List[str]]:
         if count is None:
             return "Mooo"
         return ["Mooo"] * count

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -25,6 +25,7 @@ def test_samples(samplefile, mypy_cache_dir):
     opts.cache_dir = mypy_cache_dir
     opts.show_traceback = True
     opts.namespace_packages = True
+    opts.hide_error_codes = True
     opts.plugins = ['mypy_zope:plugin']
     # Config file is needed to load plugins, it doesn't not exist and is not
     # supposed to.


### PR DESCRIPTION
For your consideration: an attempt to update this plugin to work with the recent mypy 1.0.0 release.

https://github.com/Shoobx/mypy-zope/pull/85 was an attempt to establish compatibility with mypy 0.991. It was partially successful, but ultimately blocked on https://github.com/python/mypy/issues/14106

I wanted to take a look to see if could make any progress. I think I was able to workaround the linked mypy issue with a dirty, brittle and naughty hack (see https://github.com/Shoobx/mypy-zope/pull/89/commits/da1d0fb4ef97f1d574cf0b458297def76c45ef5c). It might be too brittle to include upstream; let me know what you think.

On my machine, all but one test passes. I am not sure how to handle the failure:

<details>

```
$ pytest -vv --lf
=================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.10.9, pytest-7.1.3, pluggy-1.0.0 -- /home/dmr/workspace/mypy-zope/ve/bin/python3
cachedir: .pytest_cache
rootdir: /home/dmr/workspace/mypy-zope
plugins: cov-3.0.0
collected 1 item                                                                                                                                                                                                                                                                           
run-last-failure: rerun previous 1 failure (skipped 1 file)

tests/test_samples.py::test_samples[interface_meta] FAILED                                                                                                                                                                                                                           [100%]

========================================================================================================================================= FAILURES =========================================================================================================================================
_______________________________________________________________________________________________________________________________ test_samples[interface_meta] _______________________________________________________________________________________________________________________________

samplefile = '/home/dmr/workspace/mypy-zope/tests/samples/interface_meta.py', mypy_cache_dir = '/tmp/pytest-of-dmr/pytest-75/.mypy_cahe0'

    def test_samples(samplefile, mypy_cache_dir):
        opts = options.Options()
        opts.cache_dir = mypy_cache_dir
        opts.show_traceback = True
        opts.namespace_packages = True
        opts.hide_error_codes = True
        opts.plugins = ['mypy_zope:plugin']
        # Config file is needed to load plugins, it doesn't not exist and is not
        # supposed to.
        opts.config_file = '    not_existing_config.ini'
    
        try:
            base_dir = os.path.dirname(samplefile)
            source = BuildSource(samplefile,
                                 module=None,
                                 text=None,
                                 base_dir=base_dir)
            res = build.build(
                sources=[source],
                options=opts)
        except CompileError as e:
            assert False, e
    
        normalized = normalize_errors(res.errors, samplefile)
        actual = '\n'.join(normalized)
        expected = find_expected_output(samplefile)
>       assert actual == expected
E       assert ('interface_meta.py:13: error: Missing positional argument "object" in call to '\n '"providedBy" of "ISpecification"\n'\n 'interface_meta.py:13: error: Argument 1 to "providedBy" of "ISpecification" '\n 'has incompatible type "Type[T]"; expected "ISpecification"\n'\n 'interface_meta.py:19: note: Revealed type is "__main__.IBookmark"') == 'interface_meta.py:19: note: Revealed type is "__main__.IBookmark"'
E         + interface_meta.py:13: error: Missing positional argument "object" in call to "providedBy" of "ISpecification"
E         + interface_meta.py:13: error: Argument 1 to "providedBy" of "ISpecification" has incompatible type "Type[T]"; expected "ISpecification"
E           interface_meta.py:19: note: Revealed type is "__main__.IBookmark"

tests/test_samples.py:49: AssertionError
---------------------------------------------------------------------------------------------------------------------------------- Captured stdout setup -----------------------------------------------------------------------------------------------------------------------------------
Setup cache /tmp/pytest-of-dmr/pytest-75/.mypy_cahe0
================================================================================================================================= short test summary info ==================================================================================================================================
FAILED tests/test_samples.py::test_samples[interface_meta] - assert ('interface_meta.py:13: error: Missing positional argument "object" in call to '\n '"providedBy" of "ISpecification"\n'\n 'interface_meta.py:13: error: Argument 1 to "providedBy" of "ISpecification" '\n 'has incom...
==================================================================================================================================== 1 failed in 3.92s =====================================================================================================================================
```

</details>

Fixes #82 (I think?)
Closes #85