### PR TITLE
Include wheels into the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 1.0.7 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Include wheel into the release
 
 
 ## 1.0.6 (2024-10-10)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ classifiers =
 packages =
     mypy_zope
     zope-stubs
+    zope-stubs.schema
+    zope-stubs.interface
+    zope-stubs.interface.common
 package_dir = =src
 install_requires =
     mypy>=1.0.0,<1.12.0


### PR DESCRIPTION
Installed `zest.releaser[recommended]` locally.

Fixes #118.