### PR TITLE
Drop support for python-3.8 and fix the unittests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 1.0.13 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Drop support for python-3.8 (follow mypy). 
 
 
 ## 1.0.12 (2025-06-03)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Environment :: Console
     Intended Audience :: Developers
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11

--- a/tests/samples/interface_implications.py
+++ b/tests/samples/interface_implications.py
@@ -35,9 +35,9 @@ if __name__ == '__main__':
 <output>
 interface_implications.py:19: note: Revealed type is "None"
 interface_implications.py:21: note: Revealed type is "__main__.IBookmark"
-interface_implications.py:22: note: Revealed type is "Union[__main__.IBookmark, None]"
+interface_implications.py:22: note: Revealed type is "__main__.IBookmark | None"
 interface_implications.py:26: note: Revealed type is "type[__main__.IBookmark]"
 interface_implications.py:28: note: Revealed type is "type[None]"
-interface_implications.py:29: note: Revealed type is "Union[type[__main__.IBookmark], type[None]]"
+interface_implications.py:29: note: Revealed type is "type[__main__.IBookmark] | type[None]"
  </output>
 """

--- a/tests/samples/open.py
+++ b/tests/samples/open.py
@@ -4,6 +4,6 @@ reveal_type(open('str', 'rb'))
 """
 <output>
 open.py:1: note: Revealed type is "_io.TextIOWrapper[_io._WrappedBuffer]"
-open.py:2: note: Revealed type is "_io.BufferedReader"
+open.py:2: note: Revealed type is "_io.BufferedReader[_io._BufferedReaderStream]"
 </output>
 """


### PR DESCRIPTION
Fix the test_samples[open] and test_samples[interface_implications] unittests. #130