### PR TITLE
Bump the used github actions versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -44,7 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
     - name: Coveralls Finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 1.0.16 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Bump github actions to use node 24
 
 
 ## 1.0.15 (2026-05-18)


### PR DESCRIPTION
Bump the checkout and setup-python github actions versions to remove the deprecation warning about node 20 being used.